### PR TITLE
Fix (again) off-by-one error in nucleotide and protein sequence view.

### DIFF
--- a/src/plugin/modules/widgets/genomes/kbaseGeneSequence.js
+++ b/src/plugin/modules/widgets/genomes/kbaseGeneSequence.js
@@ -188,13 +188,13 @@ define([
                         var protDispStr = "";
                         var start_pos = 0;
                         var end_pos = 0;
-                        for (var i = 0; (i + 1) * seq_width - 1 < proteinTranslationStr.length; i++) {
+                        for (var i = 0; (i + 1) * seq_width < proteinTranslationStr.length; i++) {
                             start_pos = i * seq_width;
-                            end_pos = (i + 1) * seq_width - 1;
+                            end_pos = (i + 1) * seq_width;
                             protDispStr += proteinTranslationStr.substring(start_pos, end_pos) + '<br>';
                         }
                         start_pos += seq_width;
-                        end_pos = proteinTranslationStr.length - 1;
+                        end_pos = proteinTranslationStr.length;
                         if (start_pos < proteinTranslationStr.length) {
                             protDispStr += proteinTranslationStr.substring(start_pos, end_pos) + '<br>';
                         }


### PR DESCRIPTION
See here: https://atlassian.kbase.us/browse/KBASE-3718

Back in November this repo tried to absorb changes in ui-common, but wasn't deployed until much more recently. This fix was originally done in ui-common and just needs to be repeated here.
